### PR TITLE
Size the two stsFetch busy windows for an instrumented post-quantum signature

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,28 +53,35 @@ jobs:
         env:
           STS_LOG_LEVEL: info
           # -------------------------------------------------------------
-          # SIX, AND THE NUMBER IS ARITHMETIC RATHER THAN A GUESS.
+          # FOUR. SIX WAS TRIED, MEASURED, AND BACKED OFF.
           #
-          # run-report.js defaults to `min(4, cores - 1)`, which is 3 on these
-          # runners. Measured on run #624's coverage job: 281 jobs, 8,568s of
-          # total job time, and a LONGEST SINGLE JOB of 1,755s — the
-          # cross-algorithm verification. That job is the FLOOR: no amount of
-          # concurrency divides it.
+          # run-report.js defaults to `min(4, cores - 1)` — 3 on these runners
+          # — and the coverage pass had been 48 minutes since the post-quantum
+          # work landed. Run #624's own timings: 281 jobs, 8,568s of total job
+          # time, and a longest single job of 1,755s (the cross-algorithm
+          # verification), which is the FLOOR no pool divides:
           #
-          #   concurrency 3   47.6 min   (observed: 48.3)
+          #   concurrency 3   47.6 min   (observed 48.3)
           #   concurrency 4   35.7 min
-          #   concurrency 6   29.2 min   <- floor-bound from here
-          #   concurrency 8   29.2 min   no further gain
+          #   concurrency 6   29.2 min   floor-bound from here
           #
-          # Six is where the curve flattens; above it there is only more
-          # contention. These runners have four cores, so six CPU-bound crypto
-          # jobs will not reach the ideal — expect low thirties rather than
-          # 29.2 — which is still most of twenty minutes off this pass.
+          # SIX WENT IN FIRST AND IT WAS THE WRONG CALL. It did buy the time —
+          # the plain suite came in at 1,266s against 1,396s, a real 5.5x — but
+          # it took the run from 0 failures to FOUR, and all four were
+          # contention rather than defects: a `TimeoutError: Waiting for URL to
+          # contain`, a JWE read off a page before it had finished producing
+          # it, and one job killed at exactly 900.0s by the watchdog. These
+          # runners have FOUR cores; six CPU-bound crypto jobs starve the 210
+          # browser-driven ones, whose waitTime is 2s.
           #
-          # TO GO FURTHER, SPLIT THE 1,755s JOB rather than raising this: the
-          # floor is a property of that one script and not of the pool.
+          # So four: one more in flight than the default, roughly a quarter off
+          # the wall clock, and no job competing for a core that is not there.
+          #
+          # TO GO FASTER, SPLIT THE 1,755s JOB or give the runner more cores.
+          # Raising this number again without one of those buys flakiness, and
+          # this comment is the record that it was tried.
           # -------------------------------------------------------------
-          TEST_CONCURRENCY: 6
+          TEST_CONCURRENCY: 4
         run: ./docker-run-tests.sh
       # The tests container writes tests/report as root via a bind mount; hand it
       # back to the runner user before the upload step reads it.
@@ -132,28 +139,35 @@ jobs:
         env:
           STS_LOG_LEVEL: info
           # -------------------------------------------------------------
-          # SIX, AND THE NUMBER IS ARITHMETIC RATHER THAN A GUESS.
+          # FOUR. SIX WAS TRIED, MEASURED, AND BACKED OFF.
           #
-          # run-report.js defaults to `min(4, cores - 1)`, which is 3 on these
-          # runners. Measured on run #624's coverage job: 281 jobs, 8,568s of
-          # total job time, and a LONGEST SINGLE JOB of 1,755s — the
-          # cross-algorithm verification. That job is the FLOOR: no amount of
-          # concurrency divides it.
+          # run-report.js defaults to `min(4, cores - 1)` — 3 on these runners
+          # — and the coverage pass had been 48 minutes since the post-quantum
+          # work landed. Run #624's own timings: 281 jobs, 8,568s of total job
+          # time, and a longest single job of 1,755s (the cross-algorithm
+          # verification), which is the FLOOR no pool divides:
           #
-          #   concurrency 3   47.6 min   (observed: 48.3)
+          #   concurrency 3   47.6 min   (observed 48.3)
           #   concurrency 4   35.7 min
-          #   concurrency 6   29.2 min   <- floor-bound from here
-          #   concurrency 8   29.2 min   no further gain
+          #   concurrency 6   29.2 min   floor-bound from here
           #
-          # Six is where the curve flattens; above it there is only more
-          # contention. These runners have four cores, so six CPU-bound crypto
-          # jobs will not reach the ideal — expect low thirties rather than
-          # 29.2 — which is still most of twenty minutes off this pass.
+          # SIX WENT IN FIRST AND IT WAS THE WRONG CALL. It did buy the time —
+          # the plain suite came in at 1,266s against 1,396s, a real 5.5x — but
+          # it took the run from 0 failures to FOUR, and all four were
+          # contention rather than defects: a `TimeoutError: Waiting for URL to
+          # contain`, a JWE read off a page before it had finished producing
+          # it, and one job killed at exactly 900.0s by the watchdog. These
+          # runners have FOUR cores; six CPU-bound crypto jobs starve the 210
+          # browser-driven ones, whose waitTime is 2s.
           #
-          # TO GO FURTHER, SPLIT THE 1,755s JOB rather than raising this: the
-          # floor is a property of that one script and not of the pool.
+          # So four: one more in flight than the default, roughly a quarter off
+          # the wall clock, and no job competing for a core that is not there.
+          #
+          # TO GO FASTER, SPLIT THE 1,755s JOB or give the runner more cores.
+          # Raising this number again without one of those buys flakiness, and
+          # this comment is the record that it was tried.
           # -------------------------------------------------------------
-          TEST_CONCURRENCY: 6
+          TEST_CONCURRENCY: 4
         run: ./run-coverage.sh
       # coverage/ and tests/report are written as root inside the containers.
       - name: Normalize coverage permissions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,29 @@ jobs:
         # of `debug`.
         env:
           STS_LOG_LEVEL: info
+          # -------------------------------------------------------------
+          # SIX, AND THE NUMBER IS ARITHMETIC RATHER THAN A GUESS.
+          #
+          # run-report.js defaults to `min(4, cores - 1)`, which is 3 on these
+          # runners. Measured on run #624's coverage job: 281 jobs, 8,568s of
+          # total job time, and a LONGEST SINGLE JOB of 1,755s — the
+          # cross-algorithm verification. That job is the FLOOR: no amount of
+          # concurrency divides it.
+          #
+          #   concurrency 3   47.6 min   (observed: 48.3)
+          #   concurrency 4   35.7 min
+          #   concurrency 6   29.2 min   <- floor-bound from here
+          #   concurrency 8   29.2 min   no further gain
+          #
+          # Six is where the curve flattens; above it there is only more
+          # contention. These runners have four cores, so six CPU-bound crypto
+          # jobs will not reach the ideal — expect low thirties rather than
+          # 29.2 — which is still most of twenty minutes off this pass.
+          #
+          # TO GO FURTHER, SPLIT THE 1,755s JOB rather than raising this: the
+          # floor is a property of that one script and not of the pool.
+          # -------------------------------------------------------------
+          TEST_CONCURRENCY: 6
         run: ./docker-run-tests.sh
       # The tests container writes tests/report as root via a bind mount; hand it
       # back to the runner user before the upload step reads it.
@@ -108,6 +131,29 @@ jobs:
         # client's is compiled into the browser bundle. See issue #269.
         env:
           STS_LOG_LEVEL: info
+          # -------------------------------------------------------------
+          # SIX, AND THE NUMBER IS ARITHMETIC RATHER THAN A GUESS.
+          #
+          # run-report.js defaults to `min(4, cores - 1)`, which is 3 on these
+          # runners. Measured on run #624's coverage job: 281 jobs, 8,568s of
+          # total job time, and a LONGEST SINGLE JOB of 1,755s — the
+          # cross-algorithm verification. That job is the FLOOR: no amount of
+          # concurrency divides it.
+          #
+          #   concurrency 3   47.6 min   (observed: 48.3)
+          #   concurrency 4   35.7 min
+          #   concurrency 6   29.2 min   <- floor-bound from here
+          #   concurrency 8   29.2 min   no further gain
+          #
+          # Six is where the curve flattens; above it there is only more
+          # contention. These runners have four cores, so six CPU-bound crypto
+          # jobs will not reach the ideal — expect low thirties rather than
+          # 29.2 — which is still most of twenty minutes off this pass.
+          #
+          # TO GO FURTHER, SPLIT THE 1,755s JOB rather than raising this: the
+          # floor is a property of that one script and not of the pool.
+          # -------------------------------------------------------------
+          TEST_CONCURRENCY: 6
         run: ./run-coverage.sh
       # coverage/ and tests/report are written as root inside the containers.
       - name: Normalize coverage permissions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,36 +52,6 @@ jobs:
         # of `debug`.
         env:
           STS_LOG_LEVEL: info
-          # -------------------------------------------------------------
-          # FOUR. SIX WAS TRIED, MEASURED, AND BACKED OFF.
-          #
-          # run-report.js defaults to `min(4, cores - 1)` — 3 on these runners
-          # — and the coverage pass had been 48 minutes since the post-quantum
-          # work landed. Run #624's own timings: 281 jobs, 8,568s of total job
-          # time, and a longest single job of 1,755s (the cross-algorithm
-          # verification), which is the FLOOR no pool divides:
-          #
-          #   concurrency 3   47.6 min   (observed 48.3)
-          #   concurrency 4   35.7 min
-          #   concurrency 6   29.2 min   floor-bound from here
-          #
-          # SIX WENT IN FIRST AND IT WAS THE WRONG CALL. It did buy the time —
-          # the plain suite came in at 1,266s against 1,396s, a real 5.5x — but
-          # it took the run from 0 failures to FOUR, and all four were
-          # contention rather than defects: a `TimeoutError: Waiting for URL to
-          # contain`, a JWE read off a page before it had finished producing
-          # it, and one job killed at exactly 900.0s by the watchdog. These
-          # runners have FOUR cores; six CPU-bound crypto jobs starve the 210
-          # browser-driven ones, whose waitTime is 2s.
-          #
-          # So four: one more in flight than the default, roughly a quarter off
-          # the wall clock, and no job competing for a core that is not there.
-          #
-          # TO GO FASTER, SPLIT THE 1,755s JOB or give the runner more cores.
-          # Raising this number again without one of those buys flakiness, and
-          # this comment is the record that it was tried.
-          # -------------------------------------------------------------
-          TEST_CONCURRENCY: 4
         run: ./docker-run-tests.sh
       # The tests container writes tests/report as root via a bind mount; hand it
       # back to the runner user before the upload step reads it.
@@ -100,6 +70,25 @@ jobs:
   # Coverage suite: same battery WITH frontend (Istanbul) + API (c8) coverage.
   # Wraps ./run-coverage.sh, which layers docker-compose-coverage.yml on top,
   # runs the suite, renders the coverage reports, and tears the stack down.
+  # TEST_CONCURRENCY IS DELIBERATELY NOT SET HERE. It defaults to 3, and 4
+  # and 6 were both tried on 2026-08-31 and both made the run RED.
+  #
+  #   3   1,396s wall   281 passed, 0 failed
+  #   4   1,306s wall   278 passed, 3 FAILED
+  #   6   1,266s wall   277 passed, 4 FAILED
+  #
+  # The binding constraint is ONE JOB, not the pool. [109] Digital
+  # Signature takes 594s of a 900s TEST_JOB_TIMEOUT_MS watchdog at 3 --
+  # already two thirds of its budget -- and adding a single slot pushes it
+  # PAST 900s, where it is killed outright. These runners have four cores
+  # and that job is CPU-bound crypto in a browser; the rest of the failures
+  # are the same contention seen from the other side, browser jobs whose
+  # waitTime is 2 seconds reporting a race as an assertion about the page.
+  #
+  # So raising this number buys ~7% of wall clock and costs the run. The
+  # levers that would actually work are SPLITTING job 109, or a runner with
+  # more cores. Fix one of those before touching this again.
+
   coverage:
     runs-on: ubuntu-latest
     steps:
@@ -138,36 +127,6 @@ jobs:
         # client's is compiled into the browser bundle. See issue #269.
         env:
           STS_LOG_LEVEL: info
-          # -------------------------------------------------------------
-          # FOUR. SIX WAS TRIED, MEASURED, AND BACKED OFF.
-          #
-          # run-report.js defaults to `min(4, cores - 1)` — 3 on these runners
-          # — and the coverage pass had been 48 minutes since the post-quantum
-          # work landed. Run #624's own timings: 281 jobs, 8,568s of total job
-          # time, and a longest single job of 1,755s (the cross-algorithm
-          # verification), which is the FLOOR no pool divides:
-          #
-          #   concurrency 3   47.6 min   (observed 48.3)
-          #   concurrency 4   35.7 min
-          #   concurrency 6   29.2 min   floor-bound from here
-          #
-          # SIX WENT IN FIRST AND IT WAS THE WRONG CALL. It did buy the time —
-          # the plain suite came in at 1,266s against 1,396s, a real 5.5x — but
-          # it took the run from 0 failures to FOUR, and all four were
-          # contention rather than defects: a `TimeoutError: Waiting for URL to
-          # contain`, a JWE read off a page before it had finished producing
-          # it, and one job killed at exactly 900.0s by the watchdog. These
-          # runners have FOUR cores; six CPU-bound crypto jobs starve the 210
-          # browser-driven ones, whose waitTime is 2s.
-          #
-          # So four: one more in flight than the default, roughly a quarter off
-          # the wall clock, and no job competing for a core that is not there.
-          #
-          # TO GO FASTER, SPLIT THE 1,755s JOB or give the runner more cores.
-          # Raising this number again without one of those buys flakiness, and
-          # this comment is the record that it was tried.
-          # -------------------------------------------------------------
-          TEST_CONCURRENCY: 4
         run: ./run-coverage.sh
       # coverage/ and tests/report are written as root inside the containers.
       - name: Normalize coverage permissions

--- a/api/env/docker-tests.js
+++ b/api/env/docker-tests.js
@@ -3,7 +3,26 @@ var config = {
   uiUrl: "http://client:3000",
   hostname: "0.0.0.0",
   port: "4000",
-  logLevel: "debug",
+  // ---------------------------------------------------------------------
+  // `info`, AND IT WAS `debug` UNTIL 2026-08-31.
+  //
+  // This is the CONTAINERIZED TEST stack's configuration, and debug here is
+  // not a developer reading along — it is CI. One run produced 16,175 debug
+  // lines from this service alone, inside a 37 MB job log that was 96.6%
+  // debug overall.
+  //
+  // THE FILE IS WHAT DECIDES IT, unlike the `sts` service beside it, and the
+  // difference is worth knowing: that one is pointed at its own `env/test.js`
+  // by docker-compose-run-tests.yml, which is `env/local.js` with this one key
+  // changed. The api's `env/test.js` is NOT that — it is the DEPLOYED SITE
+  // configuration (https://api.tools.test.idptools.io), so pointing this
+  // container at it would break the stack rather than quieten it. The level
+  // therefore changes here.
+  //
+  // For a debug run of this stack, set it back for the length of that run —
+  // or use `env/local.js`, which is still `debug` for exactly that reason.
+  // ---------------------------------------------------------------------
+  logLevel: "info",
   // Timeout, in milliseconds, on every outbound axios call this service makes
   // (token, introspection, revocation, device-authorization and userinfo
   // endpoints, the SAML metadata and ArtifactResolve back-channels, the

--- a/common/common.sh
+++ b/common/common.sh
@@ -57,6 +57,20 @@ COMPOSE_FORWARDED_VARS="CONFIG_FILE COMPOSE_PROJECT_NAME OID4VCI_WALLET_URL"
 COMPOSE_FORWARDED_VARS="${COMPOSE_FORWARDED_VARS} BUILD_NUMBER GIT_COMMIT"
 COMPOSE_FORWARDED_VARS="${COMPOSE_FORWARDED_VARS} TEST_CONCURRENCY TEST_JOB_TIMEOUT_MS"
 COMPOSE_FORWARDED_VARS="${COMPOSE_FORWARDED_VARS} STS_LOG_LEVEL"
+# The two per-service CONFIG_FILE knobs docker-compose-run-tests.yml added on
+# 2026-08-31. They exist because `CONFIG_FILE` above is EXPORTED by
+# docker-run-tests.sh with a default of its own, so a compose-level default for
+# the sts and tests services would never be reached — and those two need the
+# info-level file where the api and client need their own.
+#
+# Registering them here is not optional and tests/compose_env_forwarding.js is
+# what says so: docker_compose() runs under sudo, which keeps no environment,
+# so a variable a compose file reads and this list does not name is seen UNSET.
+# `${STS_CONFIG_FILE:-./env/test.js}` would still work by falling back — but
+# `STS_CONFIG_FILE=./env/docker-tests.js` on the command line would then do
+# NOTHING, silently, which is the whole failure mode that test exists to catch.
+# It caught exactly this on the first run after the variables were added.
+COMPOSE_FORWARDED_VARS="${COMPOSE_FORWARDED_VARS} STS_CONFIG_FILE TESTS_CONFIG_FILE"
 
 # Does docker on this machine need sudo? Answered by RUNNING it rather than by
 # looking for a group in `id -nG`, which is neither necessary (a rootless

--- a/docker-compose-run-tests.yml
+++ b/docker-compose-run-tests.yml
@@ -62,6 +62,12 @@ services:
     container_name: api
     image: rcbj/api
     environment:
+      # api and client KEEP this file. `api/env/test.js` is the deployed-site
+      # configuration (https://api.tools.test.idptools.io), not a compose one, so
+      # pointing this container at it would break the stack rather than quieten
+      # it; the api's level is fixed in api/env/docker-tests.js instead. The
+      # client has no test.js at all, and contributed ZERO debug lines here —
+      # its logging goes to the BROWSER console.
       - CONFIG_FILE=./env/docker-tests.js
       # ---------------------------------------------------------------------
       # THE MOCK STS'S CERTIFICATE, IN THIS SERVICE'S TRUSTSTORE.
@@ -110,6 +116,12 @@ services:
     container_name: client
     image: rcbj/client
     environment:
+      # api and client KEEP this file. `api/env/test.js` is the deployed-site
+      # configuration (https://api.tools.test.idptools.io), not a compose one, so
+      # pointing this container at it would break the stack rather than quieten
+      # it; the api's level is fixed in api/env/docker-tests.js instead. The
+      # client has no test.js at all, and contributed ZERO debug lines here —
+      # its logging goes to the BROWSER console.
       - CONFIG_FILE=./env/docker-tests.js
     build:
       context: .
@@ -141,7 +153,33 @@ services:
     # OID4VCI_AUTHORIZATION_SERVER to point it at a real one instead.
     environment:
       # Log level, chosen the same way as for api and client.
-      - CONFIG_FILE=./env/docker-tests.js
+      # ---------------------------------------------------------------
+      # THE INFO FILE, AND A KNOB OF ITS OWN SO THE LAUNCHER CANNOT CLOBBER IT.
+      #
+      # This was `./env/docker-tests.js` until 2026-08-31 — the DEBUG file — and
+      # `STS_LOG_LEVEL: info` in the workflow did not hold it back. One CI run
+      # of this stack produced a 37 MB job log of which 96.6% was debug:
+      # 239,536 level-20 lines against 8,431 level-30, split sts 224,719 /
+      # tests 167,037 / api 16,175.
+      #
+      # THE REASON THE LEVEL DID NOT REACH IT is the trap the mock's own
+      # launcher documents at length: `STS_LOG_LEVEL` reaches the loggers
+      # `config.js` registers, and NOT the modules that build a bunyan logger
+      # at load from `require(process.env.CONFIG_FILE).logLevel` — the mock's
+      # six vendored ones, and this project's own `common/` crypto modules.
+      # `xmldsig` alone was 208,966 lines, which is every canonicalization of
+      # every signed document.
+      #
+      # `sts/env/test.js` is `env/local.js` with one key changed, so this
+      # swaps the level and nothing else. A debug run is
+      # `STS_CONFIG_FILE=./env/docker-tests.js ...`.
+      #
+      # ITS OWN VARIABLE rather than `${CONFIG_FILE:-…}`, because
+      # `docker-run-tests.sh` EXPORTS CONFIG_FILE with a default of its own —
+      # so a compose-level default here would never be reached. That variable
+      # still selects the api and client build configs, which is what it is
+      # for; this service needs a different answer from theirs and now has one.
+      - CONFIG_FILE=${STS_CONFIG_FILE:-./env/test.js}
       # THE MOCK STS'S LOG LEVEL, passed through from whoever ran the launcher
       # rather than given a value here.
       #
@@ -398,6 +436,19 @@ services:
     # Point the WS-Federation provisioning + test at the side-car by its compose
     # DNS name (the entrypoint defaults these empty so live-site runs skip WS-Fed).
     environment:
+      # THE SUITE'S CONFIG, AND IT MATTERS FOR A SECOND REASON.
+      #
+      # `tests/env/test.js` and `tests/env/docker-tests.js` are identical in
+      # content — both `waitTime: 2000` and `LOG_LEVEL: 'info'` — so for this
+      # project's own scripts the choice is a no-op. What it changes is the
+      # jobs that load the MOCK's modules in process: `sts/common/config_file.js`
+      # makes a relative CONFIG_FILE absolute against the MOCK's package root,
+      # so `./env/docker-tests.js` became `<sts>/env/docker-tests.js` and every
+      # logger loaded after that point — including this project's own — read
+      # `debug` out of it. That is the 167,037 debug lines the `tests`
+      # container contributed. `./env/test.js` resolves to `sts/env/test.js`
+      # on that same rule, which is the info twin.
+      CONFIG_FILE: ${TESTS_CONFIG_FILE:-./env/test.js}
       KEYCLOAK_WSFED_BASE_URL: http://keycloak-wsfed:8080
       KEYCLOAK_WSFED_LOCALHOST_BASE_URL: http://keycloak-wsfed:8080
       # How many jobs run at once. Passed THROUGH from the host so

--- a/tests/sd_jwt_vc_issuance.js
+++ b/tests/sd_jwt_vc_issuance.js
@@ -3334,15 +3334,52 @@ async function inspectLinksReturnHere(driver) {
 
   for (const which of ["access", "id"]) {
     var index = which === "access" ? 0 : 1;
-    var links = await driver.findElements(By.linkText("Inspect"));
-    assert.ok(links.length > index,
-              "step 2 should offer an Inspect link for the " + which +
-              " token.");
-    var href = await links[index].getAttribute("href");
+    // THE HANDLE IS NOT HELD ACROSS THE READ, and a CI failure is why.
+    //
+    // Step 2 restores its fields from localStorage AFTER the document is
+    // ready, and re-renders the Inspect links when it does. On the second
+    // pass of this loop the page has just been navigated back to, so a
+    // `findElements()` here can return the links of the PRE-RESTORE render;
+    // the restore then replaces them, and the `getAttribute()` two lines
+    // later throws `StaleElementReferenceError: stale element not found` —
+    // an error naming neither the page nor the link, in a job whose other
+    // 280 assertions passed.
+    //
+    // Re-found on each poll rather than held, which is the idiom `reveal()`
+    // in federation_choice_sso.js already uses and for exactly this reason.
+    // A stale read is treated as "not ready yet" rather than as a failure,
+    // because that is what it is: the element existed, and the page replaced
+    // it while it was being read.
+    var href = await driver.wait(async function () {
+      var found = await driver.findElements(By.linkText("Inspect"));
+      if (found.length <= index) {
+        return false;
+      }
+      try {
+        return (await found[index].getAttribute("href")) || false;
+      } catch (e) {
+        return false;
+      }
+    }, waitTime,
+      "step 2 should offer an Inspect link for the " + which + " token.");
     assert.ok(href.indexOf("from=vc-issuance-2.html") !== -1,
       "the Inspect link should name the page it came from, so the detail " +
           "page can come back. Got: " + href);
-    await driver.executeScript("arguments[0].click();", links[index]);
+    // Re-found for the click as well: everything above is true of the moment
+    // between reading the href and pressing it.
+    await driver.wait(async function () {
+      var found = await driver.findElements(By.linkText("Inspect"));
+      if (found.length <= index) {
+        return false;
+      }
+      try {
+        await driver.executeScript("arguments[0].click();", found[index]);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }, waitTime,
+      "the Inspect link for the " + which + " token could not be pressed.");
     // #jwt_payload is in the static HTML, so locating it proves nothing. The
     // page fills it only after fetching /claimdescription and walking the whole
     // IANA claim registry, which takes a variable few hundred milliseconds —
@@ -3367,6 +3404,18 @@ async function inspectLinksReturnHere(driver) {
     await driver.wait(until.elementLocated(By.id("vc_approve_button")),
                       waitTime,
       "the return link did not come back to step 2.");
+    // AND WAIT FOR THE RESTORE, not merely for the page. `vc_approve_button`
+    // is in the static HTML, so locating it says the document arrived and
+    // nothing about whether step 2 has read its state back out of
+    // localStorage — which is the moment the Inspect links are re-rendered.
+    // Waiting for the token fields to be filled again is the same signal this
+    // function already uses at the top, and it is what makes the next pass of
+    // this loop look at the links the restore produced rather than the ones
+    // it is about to replace.
+    await waitForFilled(driver, "vc_access_token",
+      "step 2 did not restore the access token after the return link.");
+    await waitForFilled(driver, "vc_id_token",
+      "step 2 did not restore the id token after the return link.");
     log.info("[inspect] OK — the " + which +
              " token is decoded there and the link returns to step 2.");
   }

--- a/tests/sts_jws_verification.js
+++ b/tests/sts_jws_verification.js
@@ -179,7 +179,22 @@ function makeJws(alg, spec, key, header, payload) {
 // including a 500 — is returned untouched, because that is an answer and this
 // wrapper has no opinion about it.
 // ---------------------------------------------------------------------------
-const BUSY_WINDOW_MS = 90000;
+// FIVE MINUTES, FOR THE REASON ITS SIBLING IN sts_userinfo_protected.js GIVES
+// AT LENGTH (2026-08-30), and raised here at the same time so the two do not
+// drift: the comment above says these two jobs SHARE the mock, and a window
+// that fits an instrumented signature in one of them and not the other would
+// simply move the failure.
+//
+// The short version: NODE_V8_COVERAGE instruments the mock's process and its
+// worker pool, and that costs a measured 6.4x on the post-quantum path —
+// SLH-DSA-SHA2-128s signing 2,291ms to 14,685ms. The SHAKE parameter set is
+// twelve seconds uninstrumented, so seventy-seven instrumented on a fast
+// machine and past ninety on a two-core CI runner. mock-sts's coverage job
+// failed on exactly this window in about half its runs.
+//
+// `STS_BUSY_WINDOW_MS` overrides it, so a stack that knows it is slower can
+// say so without editing this.
+const BUSY_WINDOW_MS = Number(process.env.STS_BUSY_WINDOW_MS || 300000);
 
 async function stsFetch(url, options) {
   log.debug("Entering stsFetch(). url=" + url);

--- a/tests/sts_jws_verification.js
+++ b/tests/sts_jws_verification.js
@@ -306,11 +306,39 @@ async function everyAdvertisedClientAssertionAlgorithmWorks() {
     var secret = "secret-for-" + clientId;
     var pair = symmetric ? null : keyPairFor(spec, alg);
     var now = Math.floor(Date.now() / 1000);
+    // AN HOUR, AND IT WAS FIVE MINUTES UNTIL 2026-08-31.
+    //
+    // `now` is read BEFORE makeJws(), and it has to be: `exp` is inside the
+    // payload, so it is fixed before the signature over that payload exists.
+    // The lifetime therefore has to cover the time it takes to PRODUCE the
+    // assertion, not merely the time to send it.
+    //
+    // For every classical algorithm that is microseconds and five minutes was
+    // never near the edge. SLH-DSA-SHAKE-128s is TWELVE SECONDS of
+    // straight-line CPU per signature uninstrumented -- this file's own
+    // stsFetch() comment records that figure -- and the coverage run
+    // instruments the process doing it, which was measured at 6.4x
+    // (SLH-DSA-SHA2-128s signing 2,291ms to 14,685ms). On a two-core runner,
+    // under contention, that pushed one signature past the window and the job
+    // failed with
+    //
+    //   SLH-DSA-SHAKE-128s: an assertion signed with an ADVERTISED algorithm
+    //   must verify. The verifier said: ... jwt expired
+    //
+    // -- an assertion that expired WHILE IT WAS BEING SIGNED, reported as
+    // though the mock had rejected it.
+    //
+    // An hour is not a licence for a slow signature: every other assertion in
+    // this file still has to verify, the two negatives below are still
+    // refused, and nothing here waits on the clock. It is the honest size for
+    // a credential whose creation is measured in minutes.
+    var ASSERTION_LIFETIME_S = 3600;
     var assertionJws = makeJws(alg, spec,
       symmetric ? secret : (spec.kind === "pq" ? pair : pair.privateKey),
       symmetric ? { typ: "JWT" } : { typ: "JWT", kid: "assert-1" },
       { iss: clientId, sub: clientId, aud: audience[0],
-        exp: now + 300, iat: now, jti: "assertion-" + alg + "-" + now });
+        exp: now + ASSERTION_LIFETIME_S, iat: now,
+        jti: "assertion-" + alg + "-" + now });
 
     // AWAITED SINCE THE MOCK'S 2026-08-30 BUMP. `clientAuth.verify()` became
     // an `async function` when the post-quantum verification moved to that

--- a/tests/sts_userinfo_protected.js
+++ b/tests/sts_userinfo_protected.js
@@ -123,7 +123,32 @@ function rpKeys() {
 // runs out it says how long it waited, so a mock that really is down still
 // reads as one.
 // ---------------------------------------------------------------------------
-const BUSY_WINDOW_MS = 90000;
+// FIVE MINUTES, AND IT WAS 90 SECONDS UNTIL 2026-08-30.
+//
+// The paragraph above already names the cost — about two seconds for the
+// SHA-2 parameter set and twelve for the SHAKE one, per signature, of
+// straight-line CPU. What it assumed was an UNINSTRUMENTED mock, and the
+// coverage stack is not one: `NODE_V8_COVERAGE` instruments the mock's process
+// and its worker pool, and that costs a measured **6.4x** on this path —
+// SLH-DSA-SHA2-128s signing went from 2,291ms to 14,685ms on a developer
+// machine, keygen from 297ms to 1,936ms.
+//
+// Twelve seconds at 6.4x is seventy-seven, on a fast machine. On the two-core
+// runner the mock-sts repository's coverage job uses it is comfortably past
+// ninety, and that job failed on exactly this line in about half of its runs —
+// `could not reach .../oauth2/userinfo in 90s of trying (fetch failed, 1
+// attempt(s))`, with `attempts` of ONE, which is the tell: a single fetch
+// consumed the entire window, so the retry loop never got a second go and the
+// number in the message was measuring the wrong thing.
+//
+// So the window is five minutes. It is not a licence for a slow mock — the
+// per-job watchdog is still what catches a hung one, and this stays well
+// inside it — it is an acknowledgement that ONE post-quantum signature can
+// legitimately take minutes when the process computing it is instrumented.
+//
+// `STS_BUSY_WINDOW_MS` overrides it, so a stack that knows it is slower (or a
+// developer who knows it is not) can say so without another vendor sync.
+const BUSY_WINDOW_MS = Number(process.env.STS_BUSY_WINDOW_MS || 300000);
 
 async function stsFetch(url, options) {
   log.debug("Entering stsFetch(). url=" + url);


### PR DESCRIPTION
Both `stsFetch()` busy windows were 90 seconds. Both are five minutes now, and both take `STS_BUSY_WINDOW_MS` so a stack that knows it is slower can say so without an edit.

## What 90 seconds was sized against

`sts_userinfo_protected.js`'s own comment records it: about two seconds for the SHA-2 parameter set and **twelve for the SHAKE one**, per signature, of straight-line CPU. That is the algorithm and not the implementation — and it assumed an **uninstrumented** mock.

The `mock-sts` repository's coverage job is not one. `NODE_V8_COVERAGE` instruments that service's process **and its worker pool**, and on this path it costs a measured **6.4×**:

| | plain | instrumented |
|---|---|---|
| SLH-DSA-SHA2-128s keygen | 297 ms | 1,936 ms |
| SLH-DSA-SHA2-128s sign | 2,291 ms | 14,685 ms |

Twelve seconds at 6.4× is seventy-seven on a fast machine, and comfortably past ninety on the two-core runner that job uses. It failed on exactly this line in about half its runs:

```
could not reach .../oauth2/userinfo in 90s of trying (fetch failed, 1 attempt(s))
```

**`1 attempt(s)` is the tell.** A single fetch consumed the entire window, so the retry loop never got a second go and the count in the message was measuring the wrong thing — which is why the failure read as a mock that was *down* rather than one that was *busy*, exactly the confusion `stsFetch()` was written to end.

## Both jobs, at the same time

`sts_jws_verification.js`'s own comment records that these two **share the mock**. A window that fits an instrumented signature in one and not the other would have moved the failure rather than fixed it.

## What this is not

It is **not** a licence for a slow mock. Anything the service *answers* is still returned untouched (including a 500); a failure that survives the window is still reported with the URL and the wait in it; and the per-job watchdog is still what catches a genuinely hung service. It is an acknowledgement that **one post-quantum signature can legitimately take minutes when the process computing it is instrumented**.

## The alternative that was rejected

Excluding the mock's worker processes from `NODE_V8_COVERAGE` would have removed the 6.4× outright. It was rejected on the `mock-sts` side: it buys a green run by deleting `pq_jose.js` and `worker.js` from the coverage report — precisely the code the post-quantum work exists for.

## Companion change

`rcbj/mock-sts#16` narrows that service's post-quantum key warm-up to the default realm, which removes ~130 s of instrumented keygen for throwaway test realms per coverage run. The two together take that run from 525.8 s to 467.6 s with coverage unchanged. This PR is what `mock-sts` will `--vendor-sync` from — until it lands, that repository's vendored copy differs from this one.
