### PR TITLE
harden: service 'keycloak' allows for privilege escalat... in...

### DIFF
--- a/keycloak-tests.yml
+++ b/keycloak-tests.yml
@@ -18,6 +18,8 @@ services:
     command: ["start-dev", "--features=dpop"]
     hostname: keycloak
     network_mode: "host"
+    security_opt:
+      - no-new-privileges:true
     environment:
       KC_HTTP_PORT: "8080"
       # Both the modern (26+) and legacy bootstrap-admin vars, for compatibility.


### PR DESCRIPTION
## Summary
Harden input handling in `keycloak-tests.yml` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.docker-compose.security.no-new-privileges.no-new-privileges |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.docker-compose.security.no-new-privileges.no-new-privileges` |
| **File** | `keycloak-tests.yml:9` |
| **Assessment** | Defensive hardening |

**Description**: Service 'keycloak' allows for privilege escalation via setuid or setgid binaries. Add 'no-new-privileges:true' in 'security_opt' to prevent this.

## Changes
- `keycloak-tests.yml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
