### PR TITLE
Fix the api's CORS preflight route for Express 5

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -794,7 +794,16 @@ var corsOptions = {
   optionsSuccessStatus: STATUS_204
 };
 // app.use(expressLogging(logger));
-app.options("*", cors(corsOptions));
+// "/*splat" and not "*". Express 5 (here since the 2026-09-11 bump of
+// express 4.22.2 -> 5.2.1, which came in to carry a qs advisory) resolves
+// paths with path-to-regexp 8, where a wildcard MUST be named and a bare
+// "*" is not a path at all. It throws at REGISTRATION rather than on a
+// request -- `PathError: Missing parameter name at index 1: *` -- so the
+// api exits before it listens and every call from the page dies in the
+// handshake, which a browser reports as a CORS failure naming a header
+// nobody changed. The name is a formality: nothing reads req.params.splat
+// here, the route exists only so a preflight to any path gets the headers.
+app.options("/*splat", cors(corsOptions));
 app.use(cors(corsOptions));
 
 /**


### PR DESCRIPTION
**The api has not started since #294, and neither has CI.** Every Selenium
run on `master` and `develop` since 2026-09-11 02:20 is red, the scheduled
one included.

### What happened

#294 was a dependabot bump carrying a `qs` advisory. To reach qs 6.16.0 it
took **express 4.22.2 → 5.2.1** — a major version, whose resolver is
path-to-regexp 8. There a wildcard must be **named**, so the bare `"*"` in
`api/server.js:797` is no longer a path at all:

```
PathError [TypeError]: Missing parameter name at index 1: *
```

path-to-regexp throws at **registration**, not on a request, so the process
dies before it listens.

### Why it did not look like a routing bug

Nothing reports a bad route. The api container just exits; every call from
the page then dies in the TLS handshake, and the browser reports a
preflight that got no response as **a CORS error** — the exact failure mode
the repo-root `CLAUDE.md` already warns about for an untrusted certificate
on port 4000, arriving from a completely different cause. In CI it surfaces
only as `Process completed with exit code 1` after teardown.

### The fix

`"/*splat"` is the Express 5 spelling of what `"*"` meant. The name is a
formality — nothing reads `req.params.splat`; the route exists only so a
preflight to any path gets the headers.

**This is the only occurrence in the tree.** `client/` and `tests/` went to
express 5 in #290 and #291 and were unaffected, because neither registers a
wildcard route. That is why only the api died.

### Verification

Against express 5.2.1 itself, not the migration guide:

* the old `"*"` still throws that exact message — so the fix is not a placebo
* the new `"/*splat"` registers
* **the real api now boots to `api running on https://0.0.0.0:4000`** — which
  also clears every *other* route in `server.js` under path-to-regexp 8; the
  crash at line 797 had been hiding all of them
* preflights on `/claimdescription`, `/spiffe/call`, a deep nested path and
  `/` each answer **204** with the correct `Access-Control-Allow-Origin` and
  `Vary`
* an origin outside the allow-list still gets **no** `Allow-Origin`
* `GET /claimdescription` answers **200**

CI on this PR is the real check: it is the first green-capable run since the
bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkUugVyXafbyx9ETB6dZTE